### PR TITLE
Background buffering stream

### DIFF
--- a/Lindhart.Utility.IO.Streaming/Streaming.Test/BufferBackgroundStreamTest.cs
+++ b/Lindhart.Utility.IO.Streaming/Streaming.Test/BufferBackgroundStreamTest.cs
@@ -1,0 +1,67 @@
+﻿using NUnit.Framework;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Lindhart.Utility.IO.Streaming
+{
+    public class BufferBackgroundStreamTest
+    {
+        [Test]
+        [Timeout(10000)]
+        public async Task Given_ReadingFromUnderlyingStreamIsBlocked_When_Reading_Then_MustWaitForUnderlyingStreamToBeUnblocked()
+        {
+            // Setup
+            var readBuffer = new Memory<byte>(new byte[25]);
+
+            var numberOfCalls = 0;
+            var flag = new TaskCompletionSource();
+            var testInnerStream = new LargeTestStream(100, async () =>
+            {
+                if (++numberOfCalls == 2) 
+                { 
+                    await flag.Task;
+                }
+            });
+
+            var subject = new BufferBackgroundStream(testInnerStream, 50);
+
+            // Act
+            // Should be able to do this twice, since we're reading from the buffer
+            await subject.ReadAsync(readBuffer);
+            await subject.ReadAsync(readBuffer);
+
+            var task = subject.ReadAsync(readBuffer);
+
+            await Task.Delay(100);
+
+            // Assert
+            Assert.That(task.IsCompleted, Is.False);
+
+            flag.TrySetResult();
+
+            await task;
+        }
+
+        [Test]
+        public async Task Given_UnderlyingStreamThatReadsRandomNumberOfBytes_When_Reading_Then_StreamContentIsCorrect()
+        {
+            // Setup
+            var bytes = new byte[100_000];
+            Random.Shared.NextBytes(bytes);
+
+            var underlyingStream = new TestReadStream(new MemoryStream(bytes));
+
+            var subject = new BufferBackgroundStream(underlyingStream, 197);
+
+            var outputStream = new MemoryStream();
+
+            // Act
+            await subject.CopyToAsync(outputStream);
+
+            // Assert
+            CollectionAssert.AreEqual(bytes, outputStream.ToArray());
+        }
+
+    }
+}

--- a/Lindhart.Utility.IO.Streaming/Streaming.Test/BufferBackgroundStreamTest.cs
+++ b/Lindhart.Utility.IO.Streaming/Streaming.Test/BufferBackgroundStreamTest.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Lindhart.Utility.IO.Streaming
@@ -15,22 +16,29 @@ namespace Lindhart.Utility.IO.Streaming
             var readBuffer = new Memory<byte>(new byte[25]);
 
             var numberOfCalls = 0;
-            var flag = new TaskCompletionSource();
-            var testInnerStream = new LargeTestStream(100, async () =>
+            var stopReadingFromInnerStreamFlag = new TaskCompletionSource();
+            var hasReadFourTimesFlag = new TaskCompletionSource();
+            var testInnerStream = new DelegateInAsyncReadStream(new LargeTestStream(100), async () =>
             {
                 if (++numberOfCalls == 2) 
                 { 
-                    await flag.Task;
+                    await stopReadingFromInnerStreamFlag.Task;
+                }
+
+                if (numberOfCalls == 4)
+                {
+                    hasReadFourTimesFlag.TrySetResult();
                 }
             });
 
             var subject = new BufferBackgroundStream(testInnerStream, 50);
 
             // Act
-            // Should be able to do this twice, since we're reading from the buffer
+            // Should be able to do this twice, since we're reading from the buffer (this uses the first buffer)
             await subject.ReadAsync(readBuffer);
             await subject.ReadAsync(readBuffer);
 
+            // We now try to read from the second buffer, but writing to it is not yet complete as we've set a blocking task above
             var task = subject.ReadAsync(readBuffer);
 
             await Task.Delay(100);
@@ -38,9 +46,16 @@ namespace Lindhart.Utility.IO.Streaming
             // Assert
             Assert.That(task.IsCompleted, Is.False);
 
-            flag.TrySetResult();
+            // We allow the second buffer to complete writing
+            stopReadingFromInnerStreamFlag.TrySetResult();
 
+            // We should now be able to read the second buffer as writing to it is complete
             await task;
+
+            await Task.Delay(100);
+
+            // Since buffer 2 and 3 are full we should not be reading into buffer 4
+            Assert.That(hasReadFourTimesFlag.Task.IsCompleted, Is.False);
         }
 
         [Test]
@@ -63,5 +78,53 @@ namespace Lindhart.Utility.IO.Streaming
             CollectionAssert.AreEqual(bytes, outputStream.ToArray());
         }
 
+        /// <summary>
+        /// This test enforces the buffer to sometimes wait for reading to finish before it can write, and to sometimes wait for writing to finish before it can read.
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task Given_UnderlyingStreamThatReadsWithRandomDelay_When_Reading_Then_StreamContentIsCorrect()
+        {
+            // Setup
+            var bytes = new byte[100_000];
+            Random.Shared.NextBytes(bytes);
+
+            var underlyingStream = new DelegateInAsyncReadStream(new TestReadStream(new MemoryStream(bytes)), async () => await Task.Delay(Random.Shared.Next(80)));
+
+            var subject = new BufferBackgroundStream(underlyingStream, 9000);
+
+            var outputStream = new MemoryStream();
+
+            // Act
+            var readBuffer = new Memory<byte>(new byte[8999]);
+            var count = -1;
+            while (count != 0)
+            {
+                await Task.Delay(Random.Shared.Next(80));
+                count = await subject.ReadAsync(readBuffer);
+
+                if (count != 0)
+                    await outputStream.WriteAsync(readBuffer.Slice(0, count));
+            }
+
+            // Assert
+            CollectionAssert.AreEqual(bytes, outputStream.ToArray());
+        }
+
+        private class DelegateInAsyncReadStream : DelegatingStream
+        {
+            private readonly Func<Task> _asyncDelegate;
+
+            public DelegateInAsyncReadStream(Stream innerStream, Func<Task> asyncDelegate) : base(innerStream)
+            {
+                this._asyncDelegate = asyncDelegate;
+            }
+
+            public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                await _asyncDelegate();
+                return await base.ReadAsync(buffer, offset, count, cancellationToken);
+            }
+        }
     }
 }

--- a/Lindhart.Utility.IO.Streaming/Streaming.Test/GlobalSettings.cs
+++ b/Lindhart.Utility.IO.Streaming/Streaming.Test/GlobalSettings.cs
@@ -1,1 +1,2 @@
 ﻿using NUnit.Framework;
+[assembly:Parallelizable(ParallelScope.All)]

--- a/Lindhart.Utility.IO.Streaming/Streaming.Test/LargeTestStream.cs
+++ b/Lindhart.Utility.IO.Streaming/Streaming.Test/LargeTestStream.cs
@@ -12,14 +12,10 @@ namespace Lindhart.Utility.IO.Streaming
 
         private long _bytesLeft;
 
-        public LargeTestStream(long numberOfBytes) : this(numberOfBytes, () => Task.CompletedTask)
-        { }
-
-        public LargeTestStream(long numberOfBytes, Func<Task> readAsyncDelegate)
+        public LargeTestStream(long numberOfBytes)
         {
             TotalBytes = _bytesLeft = numberOfBytes;
-            _random = new Random();
-            _readAsyncDelegate = readAsyncDelegate;
+            _random = new Random();            
         }
 
         public long TotalBytes { get; }
@@ -58,13 +54,6 @@ namespace Lindhart.Utility.IO.Streaming
 
             _bytesLeft -= back;
 
-            return back;
-        }
-
-        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            await _readAsyncDelegate();
-            var back = Read(buffer, offset, count);
             return back;
         }
 

--- a/Lindhart.Utility.IO.Streaming/Streaming.Test/LargeTestStream.cs
+++ b/Lindhart.Utility.IO.Streaming/Streaming.Test/LargeTestStream.cs
@@ -7,14 +7,19 @@ namespace Lindhart.Utility.IO.Streaming
 {
     public class LargeTestStream : Stream
     {
-        private Random _random;
+        private readonly Func<Task> _readAsyncDelegate;
+        private readonly Random _random;
 
         private long _bytesLeft;
 
-        public LargeTestStream(long NumberOfBytes)
+        public LargeTestStream(long numberOfBytes) : this(numberOfBytes, () => Task.CompletedTask)
+        { }
+
+        public LargeTestStream(long numberOfBytes, Func<Task> readAsyncDelegate)
         {
-            TotalBytes = _bytesLeft = NumberOfBytes;
+            TotalBytes = _bytesLeft = numberOfBytes;
             _random = new Random();
+            _readAsyncDelegate = readAsyncDelegate;
         }
 
         public long TotalBytes { get; }
@@ -56,10 +61,11 @@ namespace Lindhart.Utility.IO.Streaming
             return back;
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
+            await _readAsyncDelegate();
             var back = Read(buffer, offset, count);
-            return Task.FromResult(back);
+            return back;
         }
 
         public override long Seek(long offset, SeekOrigin origin)

--- a/Lindhart.Utility.IO.Streaming/Streaming/Buffer.cs
+++ b/Lindhart.Utility.IO.Streaming/Streaming/Buffer.cs
@@ -10,9 +10,16 @@ namespace Lindhart.Utility.IO.Streaming
     /// </summary>
     internal class Buffer
     {
-        private readonly byte[] _bufferBytes;
         private readonly int _bufferSize;
 
+        /// <summary>
+        /// Array of bytes that constitutes the buffer.
+        /// </summary>
+        private readonly byte[] _bufferBytes;
+
+        /// <summary>
+        /// This wraps the <see cref="_bufferBytes"/>. This is for convenience when reading.
+        /// </summary>
         private readonly MemoryStream _bufferStream;
 
         private readonly SemaphoreSlim _readBuffer;
@@ -51,7 +58,7 @@ namespace Lindhart.Utility.IO.Streaming
                 await _readBuffer.WaitAsync(token);
                 _readingInProgress = true;
             }
-
+            
             int readCount = await _bufferStream.ReadAsync(buffer, token);
 
             if (readCount == 0)

--- a/Lindhart.Utility.IO.Streaming/Streaming/Buffer.cs
+++ b/Lindhart.Utility.IO.Streaming/Streaming/Buffer.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lindhart.Utility.IO.Streaming
+{
+    /// <summary>
+    /// Buffer. Will not allow reading before it has been written. Will not allow writing before the previously written bytes have been read.
+    /// </summary>
+    internal class Buffer
+    {
+        private readonly byte[] _bufferBytes;
+        private readonly int _bufferSize;
+
+        private readonly MemoryStream _bufferStream;
+
+        private readonly SemaphoreSlim _readBuffer;
+
+        private readonly SemaphoreSlim _writeBuffer;
+
+        private bool _readingInProgress;
+
+        public bool EndOfStream { get; private set; }
+
+        public Buffer(int bufferSize)
+        {
+            _bufferSize = bufferSize;
+            _bufferBytes = new byte[bufferSize];
+            _bufferStream = new MemoryStream(_bufferBytes);
+
+            // We cannot read in the start, since the buffers are not written yet.
+            _readBuffer = new SemaphoreSlim(0, 1);
+
+            // We can write in the start.
+            _writeBuffer = new SemaphoreSlim(1, 1);
+        }
+
+        /// <summary>
+        /// Reads from the buffer. Will wait if the buffer has not yet been written to.
+        /// </summary>
+        /// <param name="buffer"></param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        internal async Task<int> ReadAsync(Memory<byte> buffer, CancellationToken token)
+        {
+            // Check if we are already in the process of reading
+            if (!_readingInProgress)
+            {
+                // Wait until write is complete
+                await _readBuffer.WaitAsync(token);
+                _readingInProgress = true;
+            }
+
+            int readCount = await _bufferStream.ReadAsync(buffer, token);
+
+            if (readCount == 0)
+            {
+                // We have read the entire buffer and thus are no longer in the process of reading this. Therefore writing is also allowed.
+                _readingInProgress = false;
+                _writeBuffer.Release();
+            }
+
+            return readCount;
+        }
+
+        /// <summary>
+        /// Fills the buffer with bytes from the stream or until the stream is empty. If the buffer already contains bytes, it will wait until those bytes have been read.
+        /// </summary>
+        /// <param name="readFrom"></param>
+        /// <returns></returns>
+        internal async Task WriteBuffer(Stream readFrom, CancellationToken token)
+        {
+            // Wait until read is complete
+            await _writeBuffer.WaitAsync(token);
+
+            int readCount = 0;
+            int count;
+
+            do
+            {
+                count = await readFrom.ReadAsync(_bufferBytes, readCount, _bufferSize - readCount, token);
+                readCount += count;
+            }
+            while (readCount < _bufferSize && count != 0);
+
+            _bufferStream.SetLength(readCount);
+            _bufferStream.Position = 0;
+            EndOfStream = count == 0;
+
+            // Allow reading of the buffer
+            _readBuffer.Release();            
+        }
+    }
+}

--- a/Lindhart.Utility.IO.Streaming/Streaming/BufferBackgroundStream.cs
+++ b/Lindhart.Utility.IO.Streaming/Streaming/BufferBackgroundStream.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,14 +11,12 @@ namespace Lindhart.Utility.IO.Streaming
     /// </summary>
     public class BufferBackgroundStream : Stream
     {
-        private const int DefaultBufferSize = 100000;
+        private const int DefaultBufferSize = 100_000;
 
         /// <summary>
         /// The stream that is wrapped
         /// </summary>
         private readonly Stream _innerStream;
-
-        private readonly int _bufferSize;
 
         private readonly Buffer _buffer1;
         private readonly Buffer _buffer2;
@@ -35,19 +32,16 @@ namespace Lindhart.Utility.IO.Streaming
                 
         private long _position;
         
-        
-
         /// <summary>
         /// 
         /// </summary>
         /// <param name="innerStream">The <see cref="Stream"/> to wrap and read from.</param>
-        /// <param name="bufferSize">The size of the buffer. Note that double this size will be used since there will be a buffer to read from, while another buffer can be used in the background to fetch data in parallel.</param>
+        /// <param name="bufferSize">The size of the buffer. Note that double this size will be used since there will be a buffer to read from, while another buffer can be used in the background to fetch data in parallel. 
+        /// The default buffer size is 100 KB (thereby using 200 KB memory)</param>
         public BufferBackgroundStream(Stream innerStream, int bufferSize = DefaultBufferSize)
         {
             _buffer1ReadActive = true;
             _innerStream = innerStream;
-
-            _bufferSize = bufferSize;
 
             _buffer1 = new Buffer(bufferSize);
             _buffer2 = new Buffer(bufferSize);

--- a/Lindhart.Utility.IO.Streaming/Streaming/BufferBackgroundStream.cs
+++ b/Lindhart.Utility.IO.Streaming/Streaming/BufferBackgroundStream.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Drawing;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lindhart.Utility.IO.Streaming
+{
+    /// <summary>
+    /// A class to wrap around an existing <see cref="Stream"/>. This will use a thread to enable processing content from the buffer, while reading new bytes from the underlying <see cref="Stream"/>. 
+    /// This is especially usefull when reading from a network (hence <see cref="System.Net.Sockets.NetworkStream"/>) or reading from a <see cref="Stream"/> that does another job, example compressing or calculating hash.
+    /// </summary>
+    public class BufferBackgroundStream : Stream
+    {
+        private const int DefaultBufferSize = 100000;
+
+        /// <summary>
+        /// The stream that is wrapped
+        /// </summary>
+        private readonly Stream _innerStream;
+
+        private readonly int _bufferSize;
+
+        private readonly Buffer _buffer1;
+        private readonly Buffer _buffer2;
+
+        private readonly CancellationTokenSource _cancellationTokenSource;
+
+        private readonly Task _backGroundWorker;
+
+        /// <summary>
+        /// True if we should read from buffer 1, false if we should read from buffer 2
+        /// </summary>
+        private bool _buffer1ReadActive;
+                
+        private long _position;
+        
+        
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="innerStream">The <see cref="Stream"/> to wrap and read from.</param>
+        /// <param name="bufferSize">The size of the buffer. Note that double this size will be used since there will be a buffer to read from, while another buffer can be used in the background to fetch data in parallel.</param>
+        public BufferBackgroundStream(Stream innerStream, int bufferSize = DefaultBufferSize)
+        {
+            _buffer1ReadActive = true;
+            _innerStream = innerStream;
+
+            _bufferSize = bufferSize;
+
+            _buffer1 = new Buffer(bufferSize);
+            _buffer2 = new Buffer(bufferSize);
+            _cancellationTokenSource = new CancellationTokenSource();
+
+            _backGroundWorker = BackgroundFillBuffersTask(_cancellationTokenSource.Token);
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => _innerStream.Length;
+
+        public override long Position { get => _position; set => throw new System.NotSupportedException(); }
+
+        public override void Close()
+        {
+            _cancellationTokenSource.Cancel();
+            base.Close();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            // On purpose the async logic has not been rewritten as sync logic (in order to avoid duplicate code).
+            // This is not pretty, but then again why would you use background thread and not run it async?
+            return ReadAsync(new Memory<byte>(buffer, offset, count), CancellationToken.None).Result;
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return await ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken);
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var activeBuffer = _buffer1ReadActive ? _buffer1 : _buffer2;
+
+            int readCount = await activeBuffer.ReadAsync(buffer, cancellationToken);
+            _position += readCount;
+
+            if (readCount != 0)
+            {
+                return readCount;
+            }
+            else
+            {
+                if (activeBuffer.EndOfStream)
+                {
+                    return 0;
+                }
+
+                // Reached the end of current buffer - switching to the other one
+                _buffer1ReadActive = !_buffer1ReadActive;
+
+                // We've reached the end of one of the buffers and just call the method recursively hitting the other buffer
+                return await ReadAsync(buffer, cancellationToken);
+            }            
+        }
+
+        private async Task BackgroundFillBuffersTask(CancellationToken token)
+        {
+            while (!_buffer1.EndOfStream && !_buffer2.EndOfStream && !token.IsCancellationRequested)
+            {
+                await _buffer1.WriteBuffer(_innerStream, token);
+
+                await _buffer2.WriteBuffer(_innerStream, token);
+            }
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new System.NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new System.NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new System.NotSupportedException();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -14,3 +14,6 @@ Can be usefull to track the number of bytes read or written. Rather usefull if y
 
 ## StreamInverter
 Can reverse a Stream wrapper direction. Usefull if you have a Stream that takes an output Stream in the constructor, but you wanted it to take an input Stream instead. Ex. when using the Stream compression methods in .net (ex. [GZipStream](https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.gzipstream?view=net-8.0)).
+
+## BufferBackgroundStream
+A double buffer stream that will allow reading from one buffer while filling the other in the background using a background thread. Usefull for paralizing multiple time consuming stream operations. Example if you both want to calculate hash for a Stream and then compress it. Or receive it via network, compress and store in database (here you might want to use this class twice).


### PR DESCRIPTION
Added a new buffer stream that can buffer in the background using a seperate thread. It operates with two buffers, so it is capable of being read from, while simultaneously reading from an underlying stream.